### PR TITLE
Add paginator utility

### DIFF
--- a/src/commands/util/testCommand.ts
+++ b/src/commands/util/testCommand.ts
@@ -1,13 +1,29 @@
-import { CommandInteraction } from 'discord.js';
+import { CommandInteraction, MessageEmbed } from 'discord.js';
 import { Command, inChannelNames } from '@knighthacks/dispatch';
 import { Channels } from '../../channels';
+import { sendPaginatedEmbeds } from '../../util/paginator';
+
+const embed1 = new MessageEmbed()
+  .setTitle('test1');
+const embed2 = new MessageEmbed()
+  .setTitle('test2');
+const embed3 = new MessageEmbed()
+  .setTitle('test3');
 
 const command: Command = {
   name: 'test',
   description: 'a test command',
   permissionHandler: inChannelNames(Channels.bot),
   async run(interaction: CommandInteraction): Promise<void> {
-    await interaction.reply('Hello from dispatch');
+    await sendPaginatedEmbeds(interaction, [
+      embed1,
+      embed2,
+      embed3,
+    ], {
+      nextLabel: 'Bar',
+      previousLabel: 'foo',
+      style: 'DANGER',
+    });
   }
 };
 

--- a/src/util/paginator.ts
+++ b/src/util/paginator.ts
@@ -21,7 +21,7 @@ export async function sendPaginatedEmbeds(interaction: CommandInteraction, embed
 
   const generateOptionsForPage = (page: number): InteractionReplyOptions => {
 
-    const begining = page === 0;
+    const beginning = page === 0;
     const end = page === embeds.length - 1;
     const currentEmbed = embeds[page];
     
@@ -45,7 +45,7 @@ export async function sendPaginatedEmbeds(interaction: CommandInteraction, embed
       .setLabel(options?.previousLabel ?? 'Previous')
       .setStyle(buttonStyle);
 
-    if (begining) {
+    if (beginning) {
       previousButton.disabled = true;
     }
 

--- a/src/util/paginator.ts
+++ b/src/util/paginator.ts
@@ -1,0 +1,83 @@
+import { CommandInteraction, InteractionReplyOptions, Message, MessageActionRow, MessageButton, MessageButtonStyle, MessageEmbed } from 'discord.js';
+
+type PageButtonOptions = {
+  style?: Omit<MessageButtonStyle, 'LINK'>;
+  nextLabel?: string;
+  previousLabel?: string;
+};
+
+/**
+ * Sends a paginated message from the given embeds.
+ * @param interaction The interaction to reply to.
+ * @param embeds The array of embeds to use.
+ */
+export async function sendPaginatedEmbeds(interaction: CommandInteraction, embeds: MessageEmbed[], options?: PageButtonOptions): Promise<void> {
+  let currentPage = 0;
+
+  // Precheck
+  if (interaction.replied) {
+    throw new Error('Cannot paginate when interaction is already replied to.');
+  }
+
+  const generateOptionsForPage = (page: number): InteractionReplyOptions => {
+
+    const begining = page === 0;
+    const end = page === embeds.length - 1;
+    const currentEmbed = embeds[page];
+    
+    const buttonStyle = options?.style ?? 'PRIMARY';
+
+    if (!currentEmbed) {
+      throw new Error('Embed page number out of bounds');
+    }
+
+    const nextButton = new MessageButton()
+      .setCustomId('nextButton')
+      .setLabel(options?.nextLabel ?? 'Next')
+      .setStyle(buttonStyle as MessageButtonStyle);
+
+    if (end) {
+      nextButton.disabled = true;
+    }
+
+    const previousButton = new MessageButton()
+      .setCustomId('previousButton')
+      .setLabel(options?.previousLabel ?? 'Previous')
+      .setStyle(buttonStyle as MessageButtonStyle);
+
+    if (begining) {
+      previousButton.disabled = true;
+    }
+
+    const row = new MessageActionRow().addComponents([previousButton, nextButton]);
+
+    return {
+      embeds: [currentEmbed],
+      components: [row],
+    };
+  };
+
+  const messageOptions = generateOptionsForPage(0);
+  const message = interaction.deferred ?
+    await interaction.followUp({ ...messageOptions, fetchReply: true }) as Message :
+    await interaction.reply({ ...messageOptions, fetchReply: true }) as Message;
+
+  const collector = message.createMessageComponentCollector({ componentType: 'BUTTON' });
+
+  collector.on('collect', async collectInteraction => {
+
+    await collectInteraction.deferUpdate();
+    if (!collectInteraction.isButton()) {
+      return;
+    }
+
+    if (collectInteraction.customId === 'nextButton') {
+      currentPage++;
+    } else {
+      currentPage--;
+    }
+
+    const replyOptions = generateOptionsForPage(currentPage);
+    await collectInteraction.editReply(replyOptions);
+  });
+}

--- a/src/util/paginator.ts
+++ b/src/util/paginator.ts
@@ -1,7 +1,7 @@
 import { CommandInteraction, InteractionReplyOptions, Message, MessageActionRow, MessageButton, MessageButtonStyle, MessageEmbed } from 'discord.js';
 
 type PageButtonOptions = {
-  style?: Omit<MessageButtonStyle, 'LINK'>;
+  style?: Exclude<MessageButtonStyle, 'LINK'>;
   nextLabel?: string;
   previousLabel?: string;
 };
@@ -34,7 +34,7 @@ export async function sendPaginatedEmbeds(interaction: CommandInteraction, embed
     const nextButton = new MessageButton()
       .setCustomId('nextButton')
       .setLabel(options?.nextLabel ?? 'Next')
-      .setStyle(buttonStyle as MessageButtonStyle);
+      .setStyle(buttonStyle);
 
     if (end) {
       nextButton.disabled = true;
@@ -43,7 +43,7 @@ export async function sendPaginatedEmbeds(interaction: CommandInteraction, embed
     const previousButton = new MessageButton()
       .setCustomId('previousButton')
       .setLabel(options?.previousLabel ?? 'Previous')
-      .setStyle(buttonStyle as MessageButtonStyle);
+      .setStyle(buttonStyle);
 
     if (begining) {
       previousButton.disabled = true;

--- a/src/util/paginator.ts
+++ b/src/util/paginator.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, InteractionReplyOptions, Message, MessageActionRow, MessageButton, MessageButtonStyle, MessageEmbed } from 'discord.js';
+import { CommandInteraction, InteractionReplyOptions, Message, MessageActionRow, MessageButton, MessageButtonStyle, MessageComponentInteraction, MessageEmbed } from 'discord.js';
 
 type PageButtonOptions = {
   style?: Exclude<MessageButtonStyle, 'LINK'>;
@@ -11,7 +11,11 @@ type PageButtonOptions = {
  * @param interaction The interaction to reply to.
  * @param embeds The array of embeds to use.
  */
-export async function sendPaginatedEmbeds(interaction: CommandInteraction, embeds: MessageEmbed[], options?: PageButtonOptions): Promise<void> {
+export async function sendPaginatedEmbeds(
+  interaction: CommandInteraction | MessageComponentInteraction,
+  embeds: MessageEmbed[],
+  options?: PageButtonOptions
+): Promise<void> {
   let currentPage = 0;
 
   // Precheck


### PR DESCRIPTION
Adds a paginator utility that takes an interaction and a list of embeds, and paginates them.

It's protected against out-of-bounds scenarios by disabling buttons when at the end or beginning of a list.

<img width="282" alt="Screen Shot 2021-08-03 at 5 11 49 PM" src="https://user-images.githubusercontent.com/77477100/128086995-e7e25b70-d2ea-4747-8041-26dc54c36359.png">
<img width="268" alt="Screen Shot 2021-08-03 at 5 11 58 PM" src="https://user-images.githubusercontent.com/77477100/128087002-ff21e427-482d-4454-96c9-a265cb6338dc.png">

In addition, you can customize the button styles and the labels of each button:

<img width="261" alt="Screen Shot 2021-08-03 at 5 15 16 PM" src="https://user-images.githubusercontent.com/77477100/128087186-f3dae027-dbd2-4e61-bc26-803cb6170d1f.png">


You can refer to `testCommand.ts` for an example of usage.

Closes #26 